### PR TITLE
Check for tomo in list of run steams

### DIFF
--- a/nx_exporter_tomo.py
+++ b/nx_exporter_tomo.py
@@ -58,7 +58,7 @@ def export_tomo(run, export_dir=None):
     start_doc = run.metadata["start"]
 
     det_filepaths = {}
-    if "tomo" not in run["streams"]:
+    if "tomo" not in list(run["streams"]):
         print("No 'tomo' stream. Skipping.")
         return
     for stream in run["streams"]:


### PR DESCRIPTION
In the conda env HEX is currently using for the Prefect workers (2025-1.0-py310-tiled), the check to see if "tomo" is in the streams doesn't work unless the streams are in a list.