### PR TITLE
Dotenv dry run from uri

### DIFF
--- a/data_validation.py
+++ b/data_validation.py
@@ -26,17 +26,20 @@ def read_stream(run, stream):
 
 
 @flow
-def data_validation(uid, api_key=None):
+def data_validation(uid, api_key=None, dry_run=dry_run):
     logger = get_run_logger()
-    run = get_run(uid, api_key)
-    logger.info(f"Validating uid {run.metadata['start']['uid']}")
-    start_time = ttime.monotonic()
-    for stream in run["streams"]:
-        logger.info(f"{stream}:")
-        stream_start_time = ttime.monotonic()
-        stream_data = read_stream(run, stream)
-        stream_elapsed_time = ttime.monotonic() - stream_start_time
-        logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
-        logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
-    elapsed_time = ttime.monotonic() - start_time
-    logger.info(f"{elapsed_time = }")
+    if dry_run:
+        logger.info("Dry run: not creating Tiled client or checking streams")
+    else:
+        run = get_run(uid, api_key)
+        logger.info(f"Validating uid {run.metadata['start']['uid']}")
+        start_time = ttime.monotonic()
+        for stream in run["streams"]:
+            logger.info(f"{stream}:")
+            stream_start_time = ttime.monotonic()
+            stream_data = read_stream(run, stream)
+            stream_elapsed_time = ttime.monotonic() - stream_start_time
+            logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
+            logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
+        elapsed_time = ttime.monotonic() - start_time
+        logger.info(f"{elapsed_time = }")

--- a/data_validation.py
+++ b/data_validation.py
@@ -2,34 +2,41 @@ import os
 import time as ttime
 
 from prefect import flow, get_run_logger, task
-from prefect.blocks.system import Secret
 from tiled.client import from_profile, from_uri
+from end_of_run_workflow import get_run as get_run_eorw
 
 
-@task(retries=2, retry_delay_seconds=10)
-def read_all_streams(uid, beamline_acronym):
+@task
+def get_run(uid, api_key=None):
     logger = get_run_logger()
     tiled_server_type = os.environ.get("TILED_SERVER_TYPE")
     if tiled_server_type == "facility":
-        api_key = Secret.load("tiled-hex-api-key", _sync=True).get()
-        tiled_client = from_profile("nsls2", api_key=api_key)
-        run = tiled_client[beamline_acronym]["raw"][uid]
+        run = get_run_eorw(uid, api_key=api_key)
     elif tiled_server_type == "local":
         tiled_client = from_uri("http://localhost:8000")
         run = tiled_client[uid]
+    else:
+        raise Exception("Unknown Tiled server type")
+    return run
+
+
+@task
+def read_stream(run, stream):
+    return run[stream].read()
+
+
+@flow
+def data_validation(uid, api_key=None):
+    logger = get_run_logger()
+    run = get_run(uid, api_key)
     logger.info(f"Validating uid {run.metadata['start']['uid']}")
     start_time = ttime.monotonic()
     for stream in run["streams"]:
         logger.info(f"{stream}:")
         stream_start_time = ttime.monotonic()
-        stream_data = run[stream].read()
+        stream_data = read_stream(run, stream)
         stream_elapsed_time = ttime.monotonic() - stream_start_time
         logger.info(f"{stream} elapsed_time = {stream_elapsed_time}")
         logger.info(f"{stream} nbytes = {stream_data.nbytes:_}")
     elapsed_time = ttime.monotonic() - start_time
     logger.info(f"{elapsed_time = }")
-
-
-@flow
-def data_validation(uid):
-    read_all_streams(uid, beamline_acronym="hex")

--- a/data_validation.py
+++ b/data_validation.py
@@ -3,20 +3,20 @@ import time as ttime
 
 from prefect import flow, get_run_logger, task
 from tiled.client import from_uri
-from end_of_run_workflow import get_run as get_run_eorw
 
 
 @task
 def get_run(uid, api_key=None):
     logger = get_run_logger()
     tiled_server_type = os.environ.get("TILED_SERVER_TYPE")
-    if tiled_server_type == "facility":
-        run = get_run_eorw(uid, api_key=api_key)
+    if tiled_server_type == "facility" or not tiled_server_type:
+        tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
+        run = tiled_client["hex"]["raw"][uid]
     elif tiled_server_type == "local":
         tiled_client = from_uri("http://localhost:8000")
         run = tiled_client[uid]
     else:
-        raise Exception("Unknown Tiled server type")
+        raise Exception(f"Unknown Tiled server type: {tiled_server_type}")
     return run
 
 

--- a/data_validation.py
+++ b/data_validation.py
@@ -8,15 +8,8 @@ from tiled.client import from_uri
 @task
 def get_run(uid, api_key=None):
     logger = get_run_logger()
-    tiled_server_type = os.environ.get("TILED_SERVER_TYPE")
-    if tiled_server_type == "facility" or not tiled_server_type:
-        tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
-        run = tiled_client["hex"]["raw"][uid]
-    elif tiled_server_type == "local":
-        tiled_client = from_uri("http://localhost:8000")
-        run = tiled_client[uid]
-    else:
-        raise Exception(f"Unknown Tiled server type: {tiled_server_type}")
+    tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
+    run = tiled_client["hex"]["raw"][uid]
     return run
 
 

--- a/data_validation.py
+++ b/data_validation.py
@@ -26,7 +26,7 @@ def read_stream(run, stream):
 
 
 @flow
-def data_validation(uid, api_key=None, dry_run=dry_run):
+def data_validation(uid, api_key=None, dry_run=None):
     logger = get_run_logger()
     if dry_run:
         logger.info("Dry run: not creating Tiled client or checking streams")

--- a/data_validation.py
+++ b/data_validation.py
@@ -2,7 +2,7 @@ import os
 import time as ttime
 
 from prefect import flow, get_run_logger, task
-from tiled.client import from_profile, from_uri
+from tiled.client import from_uri
 from end_of_run_workflow import get_run as get_run_eorw
 
 

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -35,10 +35,11 @@ def log_completion():
 
 
 @flow(log_prints=True)
-def end_of_run_workflow(stop_doc, dry_run=None):
+def end_of_run_workflow(stop_doc, api_key=None, dry_run=None):
     uid = stop_doc["run_start"]
     print(f"{uid = }")
-    api_key = get_api_key_from_env(api_key=None)
+    if not api_key:
+        api_key = get_api_key_from_env(api_key=None)
     run = get_run(uid, api_key=api_key)
     start_doc = run.metadata["start"]
 

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -1,10 +1,31 @@
+import os
 from prefect import flow, get_run_logger, task
 
 from data_validation import data_validation
 from nx_exporter_edxd import export_edxd_flow
 from nx_exporter_tomo import export_tomo_flow
-from prefect.blocks.system import Secret
-from tiled.client import from_profile
+from tiled.client import from_uri
+from dotenv import load_dotenv
+
+
+def get_api_key_from_env(api_key=None):
+    logger = get_run_logger()
+    if not api_key:
+        try:
+            with open("/srv/container.secret", "r") as secrets:
+                load_dotenv(stream=secrets)
+        except Exception:
+            logger.exception("Exception while getting Tiled API key")
+        finally:
+            api_key = os.environ["TILED_API_KEY"]
+    return api_key
+
+
+@task
+def get_run(uid, api_key=None):
+    tiled_client = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)
+    run = tiled_client["hex"]["raw"][uid]
+    return run
 
 
 @task
@@ -17,9 +38,8 @@ def log_completion():
 def end_of_run_workflow(stop_doc):
     uid = stop_doc["run_start"]
     print(f"{uid = }")
-    api_key = Secret.load("tiled-hex-api-key", _sync=True).get()
-    tiled_client = from_profile("nsls2", api_key=api_key)
-    run = tiled_client["hex"]["raw"][uid]
+    api_key = get_api_key_from_env(api_key=None)
+    run = get_run(uid, api_key=api_key)
     start_doc = run.metadata["start"]
 
     exit_status = run.stop.get("exit_status")
@@ -29,10 +49,10 @@ def end_of_run_workflow(stop_doc):
 
         if scan_type in ["tomo_dark_flat", "tomo_flyscan"]:
             print("Running export_tomo_flow")
-            export_tomo_flow(uid)
+            export_tomo_flow(uid, api_key=api_key)
         elif scan_type == "edxd":
             print("Running export_edxd_flow")
-            export_edxd_flow(uid)
+            export_edxd_flow(uid, api_key=api_key)
         else:
             print("Unknown tomo scanning mode. Not exporting.")
 

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -10,14 +10,13 @@ from dotenv import load_dotenv
 
 def get_api_key_from_env(api_key=None):
     logger = get_run_logger()
-    if not api_key:
-        try:
-            with open("/srv/container.secret", "r") as secrets:
-                load_dotenv(stream=secrets)
-        except Exception:
-            logger.exception("Exception while getting Tiled API key")
-        finally:
-            api_key = os.environ["TILED_API_KEY"]
+    try:
+        with open("/srv/container.secret", "r") as secrets:
+            load_dotenv(stream=secrets)
+    except Exception:
+        logger.exception("Exception while getting Tiled API key")
+    finally:
+        api_key = os.environ["TILED_API_KEY"]
     return api_key
 
 

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -35,7 +35,7 @@ def log_completion():
 
 
 @flow(log_prints=True)
-def end_of_run_workflow(stop_doc):
+def end_of_run_workflow(stop_doc, dry_run=None):
     uid = stop_doc["run_start"]
     print(f"{uid = }")
     api_key = get_api_key_from_env(api_key=None)
@@ -49,15 +49,15 @@ def end_of_run_workflow(stop_doc):
 
         if scan_type in ["tomo_dark_flat", "tomo_flyscan"]:
             print("Running export_tomo_flow")
-            export_tomo_flow(uid, api_key=api_key)
+            export_tomo_flow(uid, api_key=api_key, dry_run=dry_run)
         elif scan_type == "edxd":
             print("Running export_edxd_flow")
-            export_edxd_flow(uid, api_key=api_key)
+            export_edxd_flow(uid, api_key=api_key, dry_run=dry_run)
         else:
             print("Unknown tomo scanning mode. Not exporting.")
 
         # Disabling until validation fixed
-        # data_validation(uid)
+        # data_validation(uid, dry_run=dry_run)
         log_completion()
     else:
         print(f"Not running flow. {exit_status = }")

--- a/nx_exporter_edxd.py
+++ b/nx_exporter_edxd.py
@@ -7,7 +7,7 @@ import tiled
 from prefect import flow, task, get_run_logger
 from prefect.blocks.system import Secret
 from tiled.client.utils import get_asset_filepaths
-from end_of_run_workflow import get_run
+from data_validation import get_run
 
 GERM_DETECTOR_KEYS = [
     "count_time",

--- a/nx_exporter_edxd.py
+++ b/nx_exporter_edxd.py
@@ -6,12 +6,8 @@ import numpy as np
 import tiled
 from prefect import flow, task
 from prefect.blocks.system import Secret
-from tiled.client import from_profile
 from tiled.client.utils import get_asset_filepaths
-
-api_key = Secret.load("tiled-hex-api-key", _sync=True).get()
-tiled_client = from_profile("nsls2", api_key=api_key)["hex"]
-tiled_client_hex = tiled_client["raw"]
+from end_of_run_workflow import get_run
 
 GERM_DETECTOR_KEYS = [
     "count_time",
@@ -156,8 +152,8 @@ def create_edxd_nxs_file(run, det_name):
 
 
 @flow(log_prints=True)
-def export_edxd_flow(ref):
+def export_edxd_flow(ref, api_key=api_key):
     print(f"tiled: {tiled.__version__}")
-    run = tiled_client_hex[ref]
+    run = get_run(ref, api_key=api_key)
     create_edxd_nxs_file(run, det_name="germ")
     print("Done!")

--- a/nx_exporter_edxd.py
+++ b/nx_exporter_edxd.py
@@ -152,7 +152,7 @@ def create_edxd_nxs_file(run, det_name):
 
 
 @flow(log_prints=True)
-def export_edxd_flow(ref, api_key=api_key, dry_run=dry_run):
+def export_edxd_flow(ref, api_key=None, dry_run=None):
     logger = get_run_logger()
     print(f"tiled: {tiled.__version__}")
     if dry_run:

--- a/nx_exporter_edxd.py
+++ b/nx_exporter_edxd.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 import tiled
-from prefect import flow, task
+from prefect import flow, task, get_run_logger
 from prefect.blocks.system import Secret
 from tiled.client.utils import get_asset_filepaths
 from end_of_run_workflow import get_run
@@ -152,8 +152,13 @@ def create_edxd_nxs_file(run, det_name):
 
 
 @flow(log_prints=True)
-def export_edxd_flow(ref, api_key=api_key):
+def export_edxd_flow(ref, api_key=api_key, dry_run=dry_run):
+    logger = get_run_logger()
     print(f"tiled: {tiled.__version__}")
-    run = get_run(ref, api_key=api_key)
-    create_edxd_nxs_file(run, det_name="germ")
+    if dry_run:
+        logger.info("Dry run: skipping writing EDXD NXS file")
+    else:
+        logger.info("Creating EDXD NXS file")
+        run = get_run(ref, api_key=api_key)
+        create_edxd_nxs_file(run, det_name="germ")
     print("Done!")

--- a/nx_exporter_tomo.py
+++ b/nx_exporter_tomo.py
@@ -269,8 +269,12 @@ def export_dark_flat(run, export_dir=None):
 
 
 @flow(log_prints=True)
-def export_tomo_flow(ref, api_key=None):
+def export_tomo_flow(ref, api_key=None, dry_run=dry_run):
+    logger = get_run_logger()
     uid = ref
+    if dry_run:
+        logger.info(f"Dry run: not exporting. tomo_scanning_mode={run.start.get('tomo_scanning_mode')}")
+        return
     run = get_run(uid, api_key=api_key)
 
     if run.start.get("tomo_scanning_mode") == "tomo_dark_flat":

--- a/nx_exporter_tomo.py
+++ b/nx_exporter_tomo.py
@@ -5,8 +5,9 @@ import h5py
 import numpy as np
 from prefect import flow, get_run_logger, task
 from prefect.blocks.system import Secret
-from tiled.client import from_profile, from_uri
+#from tiled.client import from_uri
 from tiled.client.utils import get_asset_filepaths
+from data_validation import get_run
 
 
 def get_filepath_from_run_tomo(run, stream_name):
@@ -268,16 +269,9 @@ def export_dark_flat(run, export_dir=None):
 
 
 @flow(log_prints=True)
-def export_tomo_flow(ref):
+def export_tomo_flow(ref, api_key=None):
     uid = ref
-    #tiled_server_type = os.environ.get("TILED_SERVER_TYPE")
-    #if tiled_server_type == "facility":
-    api_key = Secret.load("tiled-hex-api-key", _sync=True).get()
-    tiled_client = from_profile("nsls2", api_key=api_key)
-    run = tiled_client["hex"]["raw"][uid]
-    #elif tiled_server_type == "local":
-    #    tiled_client = from_uri("http://localhost:8000")
-    #    run = tiled_client[uid]
+    run = get_run(uid, api_key=api_key)
 
     if run.start.get("tomo_scanning_mode") == "tomo_dark_flat":
         export_dark_flat(run)

--- a/nx_exporter_tomo.py
+++ b/nx_exporter_tomo.py
@@ -5,7 +5,6 @@ import h5py
 import numpy as np
 from prefect import flow, get_run_logger, task
 from prefect.blocks.system import Secret
-#from tiled.client import from_uri
 from tiled.client.utils import get_asset_filepaths
 from data_validation import get_run
 
@@ -284,11 +283,7 @@ def export_tomo_flow(ref, api_key=None, dry_run=None):
 
 
 # if __name__ == "__main__":
-#     tiled_client = from_uri(
-#         "http://localhost:8000",
-#         api_key=os.getenv("TILED_API_KEY", ""),
-#         include_data_sources=True,
-#     )
+#     run = get_run(uid)
 #
 #     # uid = "27d30985-ca8b-46c9-93fd-64ffa7e88ac2"
 #
@@ -299,8 +294,6 @@ def export_tomo_flow(ref, api_key=None, dry_run=None):
 #     # Saved in proposals:
 #     # uid = "a1451ea2-55c5-4d45-a4c1-efc0872e4355"  # run on 2024-03-28 at ~8:10 pm, 180 deg scan, 1801 frames
 #     uid = "db2182bd-f6e9-41f4-ae3f-b4e8bd594eb0"  # run on 2024-03-29 at ~8:00 am, 360 deg scan, 3601 frames
-#
-#     run = tiled_client[uid]
 #
 #     nx_filepath = export_tomo(run, export_dir=None, file_prefix=None, counter=0)
 #     print(f"{nx_filepath = }")

--- a/nx_exporter_tomo.py
+++ b/nx_exporter_tomo.py
@@ -269,7 +269,7 @@ def export_dark_flat(run, export_dir=None):
 
 
 @flow(log_prints=True)
-def export_tomo_flow(ref, api_key=None, dry_run=dry_run):
+def export_tomo_flow(ref, api_key=None, dry_run=None):
     logger = get_run_logger()
     uid = ref
     if dry_run:

--- a/nx_exporter_tomo.py
+++ b/nx_exporter_tomo.py
@@ -273,7 +273,7 @@ def export_tomo_flow(ref, api_key=None, dry_run=None):
     logger = get_run_logger()
     uid = ref
     if dry_run:
-        logger.info(f"Dry run: not exporting. tomo_scanning_mode={run.start.get('tomo_scanning_mode')}")
+        logger.info(f"Dry run: not getting client, not exporting")
         return
     run = get_run(uid, api_key=api_key)
 

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -38,7 +38,7 @@ deployments:
         network: slirp4netns
         volumes:
           - /nsls2/data/hex/proposals:/nsls2/data/hex/proposals
-          - /srv/prefect3_docker_worker_hex/app:/srv
+          - /srv/prefect3-docker-worker-hex/app:/srv
         container_create_kwargs:
           userns_mode: "keep-id:uid=402973,gid=402973"  # workflow-hex:workflow-hex
         auto_remove: true

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -23,7 +23,7 @@ pull:
 # the deployments section allows you to provide configuration for deploying flows
 deployments:
   - name: hex-end-of-run-workflow-docker
-    version: 0.1.2
+    version: 0.1.3
     tags:
       - hex
       - main
@@ -33,14 +33,12 @@ deployments:
     work_pool:
       name: hex-work-pool-docker
       job_variables:
-        env:
-          TILED_SITE_PROFILES: /nsls2/software/etc/tiled/profiles
         image: ghcr.io/nsls2/hex-workflows:main
         image_pull_policy: Always
         network: slirp4netns
         volumes:
           - /nsls2/data/hex/proposals:/nsls2/data/hex/proposals
-          - /nsls2/software/etc/tiled:/nsls2/software/etc/tiled
+          - /srv/prefect3_docker_worker_hex/app:/srv
         container_create_kwargs:
           userns_mode: "keep-id:uid=402973,gid=402973"  # workflow-hex:workflow-hex
         auto_remove: true


### PR DESCRIPTION
Infrastructure updates and improvements in error handling

- dotenv - enable using a file containing the Tiled API key, instead of Prefect Blocks
- dry_run - steps towards enabling dry-running of workflows for basic testing
- from_uri - also for enabling testing workflows using Github actions, which run on remote hosts that cannot mount directories from our hosts

tested with a previous UUID and a personal Tiled API key, and works as expected on one of my VMs (failures for existing files, which is as expected)